### PR TITLE
Added name when parsing adtmol2 format

### DIFF
--- a/mudock/include/mudock/format/adt_mol2.hpp
+++ b/mudock/include/mudock/format/adt_mol2.hpp
@@ -75,6 +75,8 @@ namespace mudock {
           case adt_mol2_state::NONE:
             if (line.find(adt_mol2_tokens::MOLECULE_TOKEN) != std::string::npos) {
               state = adt_mol2_state::MOLECULE;
+              std::getline(desc, line);
+              molecule.properties.assign(property_type::NAME, line);
             }
             break;
           case adt_mol2_state::MOLECULE:


### PR DESCRIPTION
Assuming the name of the ligand is always the line after the `@<TRIPOS>MOLECULE` marker, this PR sets correctly the ligand name in the parsing process.