### PR TITLE
Added CPU-only CI, devcontainer and apptainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clangd \
+    clang-format \
+    cmake \
+    gdb \
+    git \
+    libboost-all-dev \
+    libopenbabel-dev \
+    libtbb-dev \
+    ninja-build \
+    openbabel \
+    pkg-config \
+    python3 \
+    ripgrep \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "muDock CPU Dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "remoteUser": "vscode",
+  "postCreateCommand": "cmake --preset dev-cpu-debug",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cmake-tools",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-vscode.cpptools",
+        "twxs.cmake"
+      ],
+      "settings": {
+        "cmake.configureOnOpen": false,
+        "cmake.useCMakePresets": "always",
+        "C_Cpp.intelliSenseEngine": "disabled"
+      }
+    }
+  }
+}

--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -1,0 +1,42 @@
+name: CPU CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-build-test:
+    name: Build and test (CPU)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libboost-all-dev \
+            libopenbabel-dev \
+            libtbb-dev \
+            openbabel
+
+      - name: Configure
+        run: cmake --preset ci-cpu-debug
+
+      - name: Build
+        run: cmake --build --preset ci-cpu-debug --parallel
+
+      - name: Test
+        run: ctest --preset ci-cpu-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,6 +432,8 @@ endif()
 # ### Testing
 # ##############################################################################
 option(MUDOCK_ENABLE_TEST "Enabel muDock tests" OFF)
+# Exit code reported by test binaries when CTest should mark them as skipped.
+set(MUDOCK_CTEST_SKIP_RETURN_CODE 77)
 if(MUDOCK_ENABLE_TEST)
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
     message(
@@ -469,7 +471,10 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # ##############################################################################
 
 # Third-party libraries that must be manually installed
-find_package(Boost CONFIG REQUIRED COMPONENTS program_options graph fiber)
+find_package(Boost QUIET CONFIG COMPONENTS program_options graph fiber)
+if(NOT Boost_FOUND)
+  find_package(Boost REQUIRED COMPONENTS program_options graph fiber)
+endif()
 find_package(OpenBabel3 REQUIRED)
 set(CMAKE_ENABLE_EXPORTS ON)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,72 @@
+{
+  "version": 6,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 25,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-cpu-debug",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "MUDOCK_ENABLE_TEST": "ON",
+        "MUDOCK_ENABLE_MPI": "OFF",
+        "MUDOCK_ENABLE_OMP": "OFF",
+        "MUDOCK_ENABLE_OMP_OFFLOAD": "OFF",
+        "MUDOCK_ENABLE_GH": "OFF",
+        "MUDOCK_ENABLE_XSIMD": "OFF",
+        "MUDOCK_ENABLE_CUDA": "OFF",
+        "MUDOCK_ENABLE_HIP": "OFF",
+        "MUDOCK_ENABLE_SYCL": "OFF",
+        "MUDOCK_CPU_ARCHITECTURES": "x86-64",
+        "MUDOCK_CPU_TUNE": "generic"
+      }
+    },
+    {
+      "name": "ci-cpu-debug",
+      "inherits": "base-cpu-debug",
+      "displayName": "CI CPU Debug",
+      "description": "Portable CPU-only Debug build with tests enabled for CI."
+    },
+    {
+      "name": "dev-cpu-debug",
+      "inherits": "base-cpu-debug",
+      "displayName": "Developer CPU Debug",
+      "description": "CPU-only Debug build with tests enabled for local development."
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "ci-cpu-debug",
+      "configurePreset": "ci-cpu-debug"
+    },
+    {
+      "name": "dev-cpu-debug",
+      "configurePreset": "dev-cpu-debug"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "ci-cpu-debug",
+      "configurePreset": "ci-cpu-debug",
+      "output": {
+        "outputOnFailure": true
+      },
+      "execution": {
+        "noTestsAction": "error",
+        "stopOnFailure": false
+      }
+    },
+    {
+      "name": "dev-cpu-debug",
+      "configurePreset": "dev-cpu-debug",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Required:
 - oneTBB
 - OpenBabel3
 
+Required when using the bundled CMake presets:
+- Ninja
+
 Optional (enabled via build flags):
 - MPI
 - OpenMP (CPU parallelism)
@@ -46,6 +49,16 @@ Basic build:
 cmake -S /path/to/muDock -B /path/to/muDock/build -DCMAKE_INSTALL_PREFIX=/install/path
 cmake --build /path/to/muDock/build
 ```
+
+Convenience presets for CPU-only development and CI are also provided:
+
+```bash
+cmake --preset dev-cpu-debug
+cmake --build --preset dev-cpu-debug
+ctest --preset dev-cpu-debug
+```
+
+These presets set `"generator": "Ninja"` in `CMakePresets.json`, so install Ninja before using them. If you prefer another generator, use the manual `cmake -S ... -B ...` flow above instead.
 
 Most useful configuration options:
 
@@ -130,6 +143,70 @@ cmake -S /path/to/muDock -B /path/to/muDock/build -DMUDOCK_ENABLE_TEST=ON -DCMAK
 cmake --build /path/to/muDock/build
 ctest --test-dir /path/to/muDock/build
 ```
+
+The repository also ships CMake presets tailored for CPU-only testing:
+
+- `dev-cpu-debug` for local development
+- `ci-cpu-debug` for automation and reproducible CI runs
+
+## CI
+
+GitHub Actions CPU CI is configured in `.github/workflows/cpu-ci.yml`.
+
+- Triggered on every `push` and `pull_request` (plus manual `workflow_dispatch`)
+- Installs the required CPU-side dependencies on `ubuntu-24.04`
+- Configures with the `ci-cpu-debug` preset
+- Builds the project and runs `ctest --preset ci-cpu-debug`
+
+The workflow intentionally uses a `Debug` build because muDock rejects `MUDOCK_ENABLE_TEST=ON` in `Release`.
+
+## Devcontainer
+
+A VS Code Dev Containers setup is provided in `.devcontainer/`.
+
+To use it:
+
+1. Open the repository in VS Code.
+2. Run `Dev Containers: Reopen in Container`.
+3. After the container is created, the project is configured automatically with `cmake --preset dev-cpu-debug`.
+
+Common commands inside the devcontainer:
+
+```bash
+cmake --build --preset dev-cpu-debug
+ctest --preset dev-cpu-debug
+```
+
+The devcontainer installs the same core CPU dependencies used by CI, plus common development tools such as `clangd`, `clang-format`, `gdb`, and `ripgrep`.
+
+## Apptainer / Singularity
+
+An Apptainer recipe is provided at `apptainer/mudock.def` for reproducible CPU-focused environments.
+
+Build the image:
+
+```bash
+apptainer build mudock-dev.sif apptainer/mudock.def
+```
+
+If your system requires it, use `--fakeroot` or your site-specific Apptainer build flow instead.
+
+Run an interactive shell with the repository mounted:
+
+```bash
+apptainer shell --bind "$PWD":/workspace mudock-dev.sif
+cd /workspace
+cmake --preset dev-cpu-debug
+cmake --build --preset dev-cpu-debug
+ctest --preset dev-cpu-debug
+```
+
+## Troubleshooting
+
+- If CMake cannot find Boost through `BoostConfig.cmake`, muDock now falls back to CMake's standard `FindBoost` module automatically.
+- If `ctest` reports no tests, confirm you configured with `MUDOCK_ENABLE_TEST=ON` or used the provided CPU debug presets.
+- If OpenBabel is found at configure time but fails at runtime, verify that the runtime package is installed in addition to the development headers.
+- If Apptainer image builds are blocked by permissions, retry with `apptainer build --fakeroot ...` or follow your cluster's container policy.
 
 ## References
 

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -72,7 +72,7 @@ target_link_libraries(
   Boost::context
   pthread
   m
-  stdc++)  
+  stdc++)
 
 if(MUDOCK_ENABLE_SYCL)
   target_link_libraries("${CMAKE_PROJECT_NAME}" Boost::fiber)

--- a/application/src/tests/CMakeLists.txt
+++ b/application/src/tests/CMakeLists.txt
@@ -2,6 +2,8 @@ add_executable_mudock(test_grid
                       "${CMAKE_CURRENT_SOURCE_DIR}/grid_test.cpp")
 target_include_directories(test_grid
                             PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/..")
+target_compile_definitions(
+  test_grid PRIVATE MUDOCK_CTEST_SKIP_RETURN_CODE=${MUDOCK_CTEST_SKIP_RETURN_CODE})
 set_target_properties(
   test_grid
   PROPERTIES CXX_STANDARD 20

--- a/application/src/tests/grid_test.cpp
+++ b/application/src/tests/grid_test.cpp
@@ -19,6 +19,15 @@
 #include <tests/autogrid.hpp>
 #include <utility>
 
+#ifndef MUDOCK_CTEST_SKIP_RETURN_CODE
+#  error "MUDOCK_CTEST_SKIP_RETURN_CODE must be defined by CMake."
+#endif
+
+namespace {
+// CTest treats this exit code as "skipped" when the grid test is not applicable.
+constexpr int ctest_skip_return_code = MUDOCK_CTEST_SKIP_RETURN_CODE;
+}
+
 template<class T>
 inline T round3dp(const T x) {
   return ((std::floor((x) *T{1000.0} + T{0.5})) / T{1000.0});
@@ -84,7 +93,7 @@ int main(int argc, char* argv[]) {
     mudock::info(std::format("Succesfully verified grid maps in {}", fld_path.string()));
   } else {
     mudock::info("Grid test requires mudock::fp_type to be double");
-    return EXIT_FAILURE;
+    return ctest_skip_return_code;
   }
   return EXIT_SUCCESS;
 }

--- a/apptainer/mudock.def
+++ b/apptainer/mudock.def
@@ -1,0 +1,44 @@
+Bootstrap: docker
+From: ubuntu:24.04
+
+%labels
+    Author muDock contributors
+    Description CPU-focused development and deployment environment for muDock
+
+%environment
+    export LANG=C.UTF-8
+    export LC_ALL=C.UTF-8
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        libboost-all-dev \
+        libopenbabel-dev \
+        libtbb-dev \
+        ninja-build \
+        openbabel \
+        pkg-config \
+        python3 \
+        ripgrep
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+
+%runscript
+    exec /bin/bash "$@"
+
+%help
+    Build the image with:
+      apptainer build mudock-dev.sif apptainer/mudock.def
+
+    Then enter the container with the repository bound in:
+      apptainer shell --bind "$PWD":/workspace mudock-dev.sif
+
+    Inside the container:
+      cd /workspace
+      cmake --preset dev-cpu-debug
+      cmake --build --preset dev-cpu-debug --parallel
+      ctest --preset dev-cpu-debug

--- a/test/grid/CMakeLists.txt
+++ b/test/grid/CMakeLists.txt
@@ -15,6 +15,8 @@ function(add_tests dir)
                COMMAND test_grid --pdbqt ${subdir}/${subdir_name}_pocket.pdbqt
                        --autogrid ${subdir}/${subdir_name}_pocket.maps.fld
       )# You can customize this
+      set_tests_properties(test_grid_${subdir_name}
+                           PROPERTIES SKIP_RETURN_CODE ${MUDOCK_CTEST_SKIP_RETURN_CODE})
     endif()
   endforeach()
 endfunction()


### PR DESCRIPTION
This PR adds an automatic CI (CPU-only) for auto-testing. It also adds support for Docker containers and Apptainer. More specifically, this PR aims to address this [issue](https://github.com/elvispolimi/muDock/issues/81).