### PR TITLE
End-to-end TBB migration: full graph with mocked scorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,57 @@
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19384509.svg)](https://doi.org/10.5281/zenodo.19384509)
 
+---
+
+> ### 🚧 WIP: migration for end-to-end TBB adoption ------- *temporary banner*
+>
+> This branch introduces a **TBB flow-graph** streaming engine as a temporary-second entry point
+> (`muDock-tbb`) alongside the legacy `parallel_pipeline` (`muDock`).
+> 
+> Currently, the graph pipeline is wired **end-to-end** with real reader, parser, batcher, and writer,
+> plus a **mock scorer** that emits a placeholder `0.0` score.
+> Hopefully, real scoring will replace the mock soon...
+> 
+> #### Done
+>
+> - New target `muDock-tbb` (built alongside `muDock`).
+> - Full flow-graph topology in `mudock/include/mudock/tbb_implementation/stream_engine_graph.hpp`, composed from per-node body classes (`reader_body`, `parser_body`, `batcher_body`, `scorer_body`, `writer_body`) and shared type aliases (`stream_engine_types.hpp`).
+> - Global memory-bound via `limiter_node`, sized by the new knob `knobs.max_ligands_in_flight` (default `100_000`).
+> - Three-phase drain: normal flow, then partial-batch flush from each device's reorder buffer, then writer buffer flush.
+>
+> #### Try it
+>
+> ```bash
+> cmake --preset dev-cpu-debug
+> cmake --build --preset dev-cpu-debug
+> ./build/dev-cpu-debug/application/muDock-tbb \
+>   --protein data/1fkb/1fkb_protein.pdb \
+>   --ligand  data/1fkb/1fkb_ligand.mol2 \
+>   --use CPP:CPU:0
+> ```
+>
+> Expected output: one line `<ligand-name> 0.0` per parsed ligand, plus `INFO` logs.
+>
+> #### Design choices worth flagging
+>
+> - **`global_ligands_limiter` is the only limiter**, which influences backpressure and memory footprint; it is decremented by the writer on successful score, and by the parser on parse-fail (avoid leaks).
+> - **`buffer_node` over `queue_node`** for intermediate hops: muDock has no ligand-ordering requirement and unordered semantics are slightly cheaper.
+> - **`shared_ptr<static_molecule>`** as the graph message type: the libtbb-dev currently shipped with Ubuntu 24.04 (oneTBB 2021.11) has a `buffer_node` that copy-constructs its internal storage, so `unique_ptr` doesn't compile as a message type. If the TBB version bundled with the base image ever bumps to one that supports move-only container messages, switch back to `unique_ptr` end-to-end.
+> - **State/body pattern per node**: each stateful body (writer, batcher) has a co-located `<x>_state` class that outlives TBB's internal body copies, simplifying the three-phase drain. The body is a pure delegate; the state owns the mutable data (buffer, reorder buffer) and hides "when to emit" policy.
+>
+> #### Follow-up...
+>
+> - Aggregate the atomic counters and performance metrics into a cohesive struct (currently scattered across `stream_engine_graph`).
+> - Whole-graph simulation with mock node bodies to probe end-to-end performance, bottlenecks, and memory footprint under controlled loads.
+> - Real scoring (`stage::prepare/operator()/teardown` with per-device scratchpad and W workers parallelism).
+> - Per-device configuration parsing (`IMPL:DEVICE:IDS[:WORKERS][:MEMORY]`).
+> - Device-subgraphs extension with per-device credit limiters, so batches aren't blindly round-robined to already saturated devices.
+> - `stop_requested` propagation, `deadline_timer`, observer.
+> - CLI wiring for `--max_ligands_in_flight` — currently uses the compile-time default.
+> - ...
+
+---
+
 muDock is a compact, Autodock-style docking engine that uses a genetic algorithm and the Autodock 4.0 energy model. It was born as a benchmarking tool for Autodock-style workflows, and today it remains a small, focused codebase for experimenting with performance techniques (kernel porting, vectorization, accelerator backends, and approximation strategies) while staying usable as a docking tool.
 
 The pipeline is intentionally split into clean stages (input parsing, scoring, search, and output), so individual pieces can be swapped or extended. That structure makes it practical to prototype new scoring functions, docking algorithms, or search strategies without rewriting the rest of the system.

--- a/application/CMakeLists.txt
+++ b/application/CMakeLists.txt
@@ -53,6 +53,16 @@ if(MUDOCK_ENABLE_MPI)
   target_link_libraries("${CMAKE_PROJECT_NAME}" PRIVATE MPI::MPI_CXX)
 endif()
 
+add_executable_mudock("muDock-tbb"
+                      "${header_files}"
+                      "${header_path}/command_line_args.cpp"
+                      "${source_path}/tbb_main.cpp")
+mudock_configure_application_target("muDock-tbb" "${header_path}")
+mudock_link_application_target("muDock-tbb")
+if(MUDOCK_ENABLE_MPI)
+  target_link_libraries("muDock-tbb" PRIVATE MPI::MPI_CXX)
+endif()
+
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/bench" bench)
 if(MUDOCK_ENABLE_TEST)
   add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/src/tests" tests)

--- a/application/src/tbb_main.cpp
+++ b/application/src/tbb_main.cpp
@@ -1,0 +1,134 @@
+#include "command_line_args.hpp"
+
+#include <cstdlib>
+#include <fstream>
+#include <limits>
+#include <memory>
+#include <mudock/compute/pipeline_selector.hpp>
+#include <mudock/format/supported_format.hpp>
+#include <mudock/molecule.hpp>
+#include <mudock/mpi_implementation/byte_range.hpp>
+#include <mudock/mudock.hpp>
+#include <mudock/tbb_implementation/stream_engine_graph.hpp>
+#include <optional>
+
+#ifdef MUDOCK_USE_MPI
+  #include <mpi.h>
+  #include <mudock/mpi_implementation/distributed_ranges.hpp>
+#endif
+
+namespace {
+  int run_selected_pipeline(std::istream& in,
+                            const mudock::supported_format format,
+                            const command_line_arguments& args,
+                            std::shared_ptr<mudock::dynamic_molecule> protein,
+                            const std::uint64_t range_end) {
+    mudock::info("Pipeline selection: search=", to_string(args.search), ", score=", to_string(args.scoring));
+
+    dispatch_selected_pipeline(args.search,
+                               args.scoring,
+                               format,
+                               [&]<typename pipeline_t>(const auto, const auto) {
+                                 pipeline_t pipe{protein};
+                                 constexpr_switch<0, mudock::get_num_supported_format(), 1>(
+                                     [&](const auto format_index) {
+                                       constexpr auto selected_format = static_cast<mudock::supported_format>(
+                                           decltype(format_index)::value);
+                                       mudock::run_stream_engine_graph<selected_format>(in,
+                                                                                        args.device_confs,
+                                                                                        args.knobs,
+                                                                                        pipe,
+                                                                                        range_end,
+                                                                                        args.time_limit_sec,
+                                                                                        args.observer);
+                                     },
+                                     format);
+                               });
+
+    return EXIT_SUCCESS;
+  }
+} // namespace
+
+int main(int argc, char** argv) {
+  const auto args                         = parse_command_line_arguments(argc, argv);
+  std::optional<mudock::byte_range> range = std::nullopt;
+  std::optional<int> rank                 = std::nullopt;
+  const auto in_format                    = mudock::parse_supported_format(args.ligand_path);
+
+#ifdef MUDOCK_USE_MPI
+  MPI_Init(&argc, &argv);
+
+  int mpi_rank = 0, nranks = 1;
+  MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+  rank = mpi_rank;
+
+  if (rank == 0) {
+    mudock::info("Running with ", nranks, " MPI processes.");
+  }
+
+  {
+    std::ifstream probe(args.ligand_path, std::ios::binary);
+    if (!probe) {
+      mudock::error("[rank ", *rank, "] Cannot open ligand file: ", args.ligand_path);
+      MPI_Abort(MPI_COMM_WORLD, 2);
+    }
+  }
+
+  constexpr_switch<0, mudock::get_num_supported_format(), 1>(
+      [&](const auto format_index) {
+        constexpr auto selected_format = static_cast<mudock::supported_format>(decltype(format_index)::value);
+        range = mudock::distribute_aligned_ranges<selected_format>(args.ligand_path, *rank, nranks);
+      },
+      in_format);
+  mudock::info("rank ", *rank, ": [", range->begin, ", ", range->end, "]\n");
+#endif
+
+  MUDOCK_MARKER_INIT;
+
+  mudock::info("Reading and parsing protein ", args.protein_path, " ...");
+  auto protein =
+      std::make_shared<mudock::dynamic_molecule>(mudock::parser<mudock::dynamic_molecule>(args.protein_path));
+
+  mudock::info("Reading ligand ", args.ligand_path, " ...");
+  std::ifstream in(args.ligand_path, std::ios::binary);
+  if (!in) {
+    if (rank) {
+      mudock::error("[rank ", *rank, "] Can't open input file ", args.ligand_path);
+    } else {
+      mudock::error("Can't open input file ", args.ligand_path);
+    }
+#ifdef MUDOCK_USE_MPI
+    MPI_Finalize();
+#endif
+    return 1;
+  }
+
+  const auto effective_range =
+      range.value_or(mudock::byte_range{0, std::numeric_limits<std::uint64_t>::max()});
+  if (effective_range.empty()) {
+    if (rank) {
+      mudock::info("[rank ", *rank, "] No work (empty range).");
+    }
+    MUDOCK_MARKER_CLOSE;
+    mudock::info("All Done!");
+#ifdef MUDOCK_USE_MPI
+    MPI_Finalize();
+#endif
+    return EXIT_SUCCESS;
+  }
+
+  in.seekg(static_cast<std::streamoff>(effective_range.begin), std::ios::beg);
+
+  const int status = run_selected_pipeline(in, in_format, args, std::move(protein), effective_range.end);
+  MUDOCK_MARKER_CLOSE;
+  if (status == EXIT_SUCCESS) {
+    mudock::info("All Done!");
+  }
+
+#ifdef MUDOCK_USE_MPI
+  MPI_Finalize();
+#endif
+
+  return status;
+}

--- a/mudock/include/mudock/knobs.hpp
+++ b/mudock/include/mudock/knobs.hpp
@@ -12,9 +12,12 @@ namespace mudock {
     std::size_t tournament_length   = 10;
     fp_type mutation_prob           = static_cast<fp_type>(0.01);
     std::optional<std::size_t> seed = std::optional<std::size_t>{};
-    std::size_t max_tbb_tokens      = 4;
+    std::size_t max_tbb_tokens      = 4;       // TODO - with flow::graph, it can be removed
     std::size_t max_bytes_per_token = 1048576; // 1 MB
     std::size_t max_tbb_queue_size  = 100000;
+
+    // todo - strategy definition (user-defined vs. automatic; starvation warning)
+    std::size_t max_ligands_in_flight = 100000;
   };
 
 } // namespace mudock

--- a/mudock/include/mudock/tbb_implementation/batcher_body.hpp
+++ b/mudock/include/mudock/tbb_implementation/batcher_body.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "stream_engine_types.hpp"
+
+#include <memory>
+#include <mudock/compute/reorder_buffer.hpp>
+#include <mudock/molecule.hpp>
+#include <optional>
+#include <utility>
+
+namespace mudock::stream_engine {
+
+  class batcher_state {
+    reorder_buffer<static_molecule> rob_;
+
+  public:
+    std::optional<lig_batch_t> add(const lig_ptr& ligand) {
+      auto uptr             = std::make_unique<static_molecule>(std::move(*ligand));
+      auto [batch, is_full] = rob_.add_ligand(std::move(uptr));
+      if (is_full) {
+        return std::optional{std::move(batch)};
+      }
+      return std::nullopt;
+    }
+
+    template<typename Sink>
+    void flush_all(Sink&& sink) {
+      while (true) {
+        auto [batch, has_batches] = rob_.flush_one();
+        if (!has_batches) {
+          break;
+        }
+        sink(std::move(batch));
+      }
+    }
+  };
+
+  class batcher_body {
+    batcher_state& state_;
+
+  public:
+    explicit batcher_body(batcher_state& state): state_(state) {}
+
+    void operator()(lig_ptr ligand, batcher_mfn_t::output_ports_type& out) const {
+      if (auto batch = state_.add(std::move(ligand))) {
+        std::get<0>(out).try_put(std::make_shared<lig_batch_t>(std::move(*batch)));
+      }
+    }
+  };
+
+} // namespace mudock::stream_engine

--- a/mudock/include/mudock/tbb_implementation/parser_body.hpp
+++ b/mudock/include/mudock/tbb_implementation/parser_body.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "stream_engine_types.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <mudock/format/reader.hpp>
+#include <mudock/format/supported_format.hpp>
+#include <mudock/molecule.hpp>
+#include <oneapi/tbb/flow_graph.h>
+#include <string>
+
+namespace mudock::stream_engine {
+
+  template<supported_format format>
+  class parser_body {
+    global_ligands_limiter_t& global_ligands_limiter_;
+    std::atomic<std::size_t>* skipped_ligands_;
+    std::atomic<bool>* stop_requested_;
+
+  public:
+    explicit parser_body(global_ligands_limiter_t& global_ligands_limiter,
+                         std::atomic<std::size_t>* skipped = nullptr,
+                         std::atomic<bool>* stop_signal    = nullptr)
+        : global_ligands_limiter_(global_ligands_limiter),
+          skipped_ligands_(skipped),
+          stop_requested_(stop_signal) {}
+
+    void operator()(const std::string& token, parser_mfn_t::output_ports_type& out) const {
+      if (stop_requested_ != nullptr && stop_requested_->load(std::memory_order_relaxed)) {
+        release_slot();
+        return;
+      }
+
+      try {
+        auto ligand = std::make_shared<static_molecule>(mudock::parser<format, static_molecule>(token));
+        std::get<0>(out).try_put(std::move(ligand));
+      } catch (const std::exception&) {
+        if (skipped_ligands_ != nullptr) {
+          skipped_ligands_->fetch_add(1, std::memory_order_relaxed);
+        }
+        release_slot();
+      }
+    }
+
+  private:
+    void release_slot() const { global_ligands_limiter_.decrementer().try_put(tbb_flow::continue_msg{}); }
+  };
+
+} // namespace mudock::stream_engine

--- a/mudock/include/mudock/tbb_implementation/reader_body.hpp
+++ b/mudock/include/mudock/tbb_implementation/reader_body.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "stream_engine_types.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <istream>
+#include <limits>
+#include <mudock/format/supported_format.hpp>
+#include <string>
+#include <string_view>
+
+namespace mudock::stream_engine {
+
+  template<supported_format format>
+  class reader_body {
+    const std::size_t max_bytes_per_token_;
+    std::istream& stream_;
+    std::size_t end_;
+    std::atomic<bool>* stop_requested_;
+
+    mutable std::string buffered_text_;
+    mutable type_of_format<format> format_splitter_;
+    mutable bool flushed_ = false;
+
+  public:
+    explicit reader_body(std::size_t max_bytes_per_token,
+                         std::istream& in,
+                         std::size_t end                = std::numeric_limits<std::size_t>::max(),
+                         std::atomic<bool>* stop_signal = nullptr)
+        : max_bytes_per_token_(max_bytes_per_token), stream_(in), stop_requested_(stop_signal) {
+      if (end != std::numeric_limits<std::size_t>::max()) {
+        end_ = end;
+        return;
+      }
+
+      const std::streampos cur = stream_.tellg();
+      stream_.seekg(0, std::ios::end);
+      end_ = static_cast<std::size_t>(stream_.tellg());
+      stream_.seekg(cur);
+    }
+
+    std::string operator()(oneapi::tbb::flow_control& fc) const {
+      auto should_stop = [&]() {
+        return stop_requested_ != nullptr && stop_requested_->load(std::memory_order_relaxed);
+      };
+
+      while (true) {
+        if (should_stop()) {
+          buffered_text_.clear();
+          flushed_ = true;
+          fc.stop();
+          return {};
+        }
+
+        if (!buffered_text_.empty()) {
+          auto input_view = std::string_view{buffered_text_};
+          const auto next = format_splitter_.next_molecule_start_index(input_view);
+          if (next != std::string_view::npos) {
+            std::string token = buffered_text_.substr(0, next);
+            buffered_text_.erase(0, next);
+            return token;
+          }
+        }
+
+        const std::streampos pos = stream_.tellg();
+        if (pos == std::streampos(-1)) {
+          if (!flushed_ && !buffered_text_.empty()) {
+            flushed_   = true;
+            auto token = std::move(buffered_text_);
+            buffered_text_.clear();
+            return token;
+          }
+          fc.stop();
+          return {};
+        }
+
+        const std::size_t cur = static_cast<std::size_t>(pos);
+        if (cur >= end_) {
+          if (!flushed_ && !buffered_text_.empty()) {
+            flushed_   = true;
+            auto token = std::move(buffered_text_);
+            buffered_text_.clear();
+            return token;
+          }
+          fc.stop();
+          return {};
+        }
+
+        const std::size_t bytes_per_token = std::min(max_bytes_per_token_, end_ - cur);
+        std::string buf(bytes_per_token, '\0');
+        stream_.read(buf.data(), static_cast<std::streamsize>(buf.size()));
+        if (stream_.gcount() <= 0) {
+          if (!flushed_ && !buffered_text_.empty()) {
+            flushed_   = true;
+            auto token = std::move(buffered_text_);
+            buffered_text_.clear();
+            return token;
+          }
+          fc.stop();
+          return {};
+        }
+
+        buf.resize(static_cast<std::size_t>(stream_.gcount()));
+        buffered_text_ += buf;
+      }
+    }
+  };
+
+} // namespace mudock::stream_engine

--- a/mudock/include/mudock/tbb_implementation/scorer_body.hpp
+++ b/mudock/include/mudock/tbb_implementation/scorer_body.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "stream_engine_types.hpp"
+
+#include <memory>
+#include <mudock/molecule.hpp>
+#include <mudock/molecule/properties.hpp>
+#include <utility>
+
+namespace mudock::stream_engine {
+
+  class scorer_body {
+  public:
+    void operator()(lig_batch_ptr batch, scorer_mfn_t::output_ports_type& out) const {
+      for (int i = 0; i < batch->num_ligands; ++i) {
+        auto& lig = batch->molecules[i];
+        if (!lig) {
+          continue;
+        }
+        lig->properties.assign(property_type::SCORE, "0.0");
+        std::get<0>(out).try_put(lig_ptr{std::move(lig)});
+      }
+    }
+  };
+
+} // namespace mudock::stream_engine

--- a/mudock/include/mudock/tbb_implementation/stream_engine_graph.hpp
+++ b/mudock/include/mudock/tbb_implementation/stream_engine_graph.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <cstddef>
+#include <istream>
+#include <limits>
+#include <memory>
+#include <mudock/format/supported_format.hpp>
+#include <mudock/knobs.hpp>
+#include <mudock/molecule.hpp>
+#include <mudock/tbb_implementation/batcher_body.hpp>
+#include <mudock/tbb_implementation/parser_body.hpp>
+#include <mudock/tbb_implementation/reader_body.hpp>
+#include <mudock/tbb_implementation/runtime_services.hpp>
+#include <mudock/tbb_implementation/scorer_body.hpp>
+#include <mudock/tbb_implementation/stream_engine_types.hpp>
+#include <mudock/tbb_implementation/writer_body.hpp>
+#include <oneapi/tbb/flow_graph.h>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace mudock {
+
+  template<supported_format format, typename pipeline_t>
+  void run_stream_engine_graph(std::istream& in,
+                               const std::vector<std::string>& configurations,
+                               const knobs& knobs,
+                               pipeline_t& pipeline,
+                               std::size_t end                      = std::numeric_limits<std::size_t>::max(),
+                               std::optional<double> time_limit_sec = std::nullopt,
+                               std::optional<double> observer_sec   = std::nullopt) {
+    using namespace stream_engine;
+
+    tbb_flow::graph g;
+
+    reader_in_t ligand_reader(g, reader_body<format>{knobs.max_bytes_per_token, in, end});
+    // todo - ^ handle stop_signal
+
+    global_ligands_limiter_t global_ligands_limiter(g, knobs.max_ligands_in_flight);
+
+    parser_mfn_t ligand_parser(g, tbb_flow::unlimited, parser_body<format>{global_ligands_limiter});
+    // todo - ^ handle stop_signal
+
+    parsed_ligands_buf_t parsed_ligands_buf(g);
+
+    writer_state writer_state;
+    writer_fn_t writer(g, tbb_flow::serial, writer_body{writer_state, global_ligands_limiter});
+
+    std::vector<device_subgraph> devices;
+    devices.reserve(configurations.size());
+
+    for (const auto& configuration: configurations) {
+      // todo - properly map "configurations" into subgraph configuration
+
+      auto state = std::make_unique<batcher_state>();
+
+      auto batcher = std::make_unique<batcher_mfn_t>(g, tbb_flow::serial, batcher_body{*state});
+
+      auto batch_buf = std::make_unique<batch_buf_t>(g);
+
+      auto scorer = std::make_unique<scorer_mfn_t>(g, /*concurrency=*/1, scorer_body{});
+
+      tbb_flow::make_edge(parsed_ligands_buf, *batcher);
+      tbb_flow::make_edge(tbb_flow::output_port<0>(*batcher), *batch_buf);
+      tbb_flow::make_edge(*batch_buf, *scorer);
+      tbb_flow::make_edge(tbb_flow::output_port<0>(*scorer), writer);
+
+      devices.push_back({std::move(state), std::move(batcher), std::move(batch_buf), std::move(scorer)});
+    }
+
+    tbb_flow::make_edge(ligand_reader, global_ligands_limiter);
+    tbb_flow::make_edge(global_ligands_limiter, ligand_parser);
+    tbb_flow::make_edge(tbb_flow::output_port<0>(ligand_parser), parsed_ligands_buf);
+
+    // --- Phase 1: drain raw ligands
+    ligand_reader.activate();
+    g.wait_for_all();
+
+    // --- Phase 2: flush rob partial batches
+    for (auto& device: devices) {
+      device.state->flush_all([&](lig_batch_t&& batch) {
+        device.batch_buf->try_put(std::make_shared<lig_batch_t>(std::move(batch)));
+      });
+    }
+    g.wait_for_all();
+
+    // --- Phase 3: flush writer buffer
+    writer_state.flush();
+
+    // todo - observer
+    // todo - timeout
+  }
+
+} // namespace mudock

--- a/mudock/include/mudock/tbb_implementation/stream_engine_types.hpp
+++ b/mudock/include/mudock/tbb_implementation/stream_engine_types.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <memory>
+#include <mudock/batch.hpp>
+#include <mudock/molecule.hpp>
+#include <oneapi/tbb/flow_graph.h>
+#include <string>
+#include <tuple>
+
+namespace mudock::stream_engine {
+  namespace tbb_flow = oneapi::tbb::flow;
+
+  using lig_ptr       = std::shared_ptr<static_molecule>;
+  using lig_batch_t   = batch<static_molecule>;
+  using lig_batch_ptr = std::shared_ptr<lig_batch_t>;
+
+  using reader_in_t              = tbb_flow::input_node<std::string>;
+  using global_ligands_limiter_t = tbb_flow::limiter_node<std::string>;
+  using parser_mfn_t             = tbb_flow::multifunction_node<std::string, std::tuple<lig_ptr>>;
+  using parsed_ligands_buf_t     = tbb_flow::buffer_node<lig_ptr>;
+  using batcher_mfn_t = tbb_flow::multifunction_node<lig_ptr, std::tuple<lig_batch_ptr>, tbb_flow::rejecting>;
+  using batch_buf_t   = tbb_flow::buffer_node<lig_batch_ptr>;
+  using scorer_mfn_t  = tbb_flow::multifunction_node<lig_batch_ptr, std::tuple<lig_ptr>, tbb_flow::rejecting>;
+  using writer_fn_t   = tbb_flow::function_node<lig_ptr>;
+
+  class batcher_state;
+
+  struct device_subgraph {
+    std::unique_ptr<batcher_state> state;
+    std::unique_ptr<batcher_mfn_t> batcher;
+    std::unique_ptr<batch_buf_t> batch_buf;
+    std::unique_ptr<scorer_mfn_t> scorer;
+  };
+
+} // namespace mudock::stream_engine

--- a/mudock/include/mudock/tbb_implementation/writer_body.hpp
+++ b/mudock/include/mudock/tbb_implementation/writer_body.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "stream_engine_types.hpp"
+
+#include <cstddef>
+#include <iostream>
+#include <mudock/molecule.hpp>
+#include <mudock/molecule/properties.hpp>
+#include <oneapi/tbb/flow_graph.h>
+#include <string>
+
+namespace mudock::stream_engine {
+
+  class writer_state {
+    static constexpr std::size_t flush_every    = 4096;
+    static constexpr std::size_t buffer_reserve = 1 << 20;
+
+    std::string buffer_;
+    std::size_t lines_ = 0;
+
+  public:
+    writer_state() { buffer_.reserve(buffer_reserve); }
+
+    void append(const static_molecule& ligand) {
+      buffer_ += ligand.properties.get(property_type::NAME);
+      buffer_ += ' ';
+      buffer_ += ligand.properties.get(property_type::SCORE);
+      buffer_ += '\n';
+      if (++lines_ % flush_every == 0) {
+        flush();
+      }
+    }
+
+    void flush() {
+      std::cout << buffer_;
+      buffer_.clear();
+    }
+  };
+
+  class writer_body {
+    writer_state& state_;
+    global_ligands_limiter_t& global_ligands_limiter_;
+
+  public:
+    writer_body(writer_state& state, global_ligands_limiter_t& global_ligands_limiter)
+        : state_(state), global_ligands_limiter_(global_ligands_limiter) {}
+
+    tbb_flow::continue_msg operator()(lig_ptr ligand) const {
+      state_.append(*ligand);
+      global_ligands_limiter_.decrementer().try_put(tbb_flow::continue_msg{});
+      return {};
+    }
+  };
+
+} // namespace mudock::stream_engine


### PR DESCRIPTION
This branch introduces a **TBB flow-graph** streaming engine as a temporary-second entry point (`muDock-tbb`) alongside the legacy `parallel_pipeline` (`muDock`).

Currently, the graph pipeline is wired **end-to-end** with real reader, parser, batcher, and writer, plus a **mock scorer** that emits a placeholder `0.0` score. Hopefully, real scoring will replace the mock soon.

 #### Done

 - New target `muDock-tbb` (built alongside `muDock`).
 - Full flow-graph topology in `mudock/include/mudock/tbb_implementation/stream_engine_graph.hpp`, composed from per-node body classes (`reader_body`, `parser_body`, `batcher_body`, `scorer_body`, `writer_body`) and shared type aliases (`stream_engine_types.hpp`).
 - Global memory-bound via `limiter_node`, sized by the new knob `knobs.max_ligands_in_flight` (default `100_000`).
 - Three-phase drain: normal flow, then partial-batch flush from each device's reorder buffer, then writer buffer flush.

 #### Try it

 ```bash
 cmake --preset dev-cpu-debug
 cmake --build --preset dev-cpu-debug
 ./build/dev-cpu-debug/application/muDock-tbb \
   --protein data/1fkb/1fkb_protein.pdb \
   --ligand  data/1fkb/1fkb_ligand.mol2 \
   --use CPP:CPU:0
 ```

 Expected output: one line `<ligand-name 0.0` per parsed ligand, plus `INFO` logs.

 #### Design choices worth flagging

 - **`global_ligands_limiter` is the only limiter**, which influences backpressure and memory footprint; it is decremented by the writer on successful score, and by the parser on parse-fail (avoid leaks).
 - **`buffer_node` over `queue_node`** for intermediate hops: muDock has no ligand-ordering requirement and unordered semantics are slightly cheaper.
 - **`shared_ptr<static_molecule`** as the graph message type: the libtbb-dev currently shipped with Ubuntu 24.04 (oneTBB 2021.11) has a `buffer_node` that copy-constructs its internal storage, so `unique_ptr` doesn't compile as a message type. If the TBB version bundled with the base image ever bumps to one that supports move-only container messages, switch back to `unique_ptr` end-to-end.
 - **State/body pattern per node**: each stateful body (writer, batcher) has a co-located `<x_state` class that outlives TBB's internal body copies, simplifying the three-phase drain. The body is a pure delegate; the state owns the mutable data (buffer, reorder buffer) and hides "when to emit" policy.

<br>

> The `README` temporary shows a banner mentioning above information as well as some **Follow-up** tasks.
